### PR TITLE
Clarify RMS naming and improve extraction cleanup

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -46,7 +46,7 @@ ARCHIVE_RESULTS = True              # упаковать подпапку каж
 DELETE_RESULT_DIR_AFTER_ZIP = True  # удалить подпапку после упаковки (оставить только ZIP)
 
 # Режим нарезки видео:
-#  - "fast_copy": без перекодирования (очень быстро), выход .avi, границы по ключкадрам
+#  - "fast_copy": без перекодирования (очень быстро), выход .avi, границы по ключевым кадрам
 #  - "h264":      перекодирование в .mp4 (точнее/совместимее), медленнее
 SEGMENT_MODE  = "fast_copy"
 FAST_MODE     = True       # быстрый seek (-ss до -i): быстрее, но границы менее точные
@@ -145,9 +145,9 @@ def percentile(values, p):
     return s[f] + (s[c] - s[f]) * (k - f)
 
 def short_time_rms_dbfs(audio: AudioSegment, win_ms=50, hop_ms=50):
-    """Возвращает (times_sec, rms_db). times — центр окна в секундах."""
+    """Возвращает (times_sec, rms_dbfs). times — центр окна в секундах."""
     n = max(1, math.ceil((len(audio) - win_ms) / hop_ms) + 1)
-    times, rms_db = [], []
+    times, rms_dbfs = [], []
     for i in range(n):
         start = i * hop_ms
         end = min(len(audio), start + win_ms)
@@ -155,16 +155,16 @@ def short_time_rms_dbfs(audio: AudioSegment, win_ms=50, hop_ms=50):
         rms = seg.rms or 1
         dbfs = 20 * math.log10(rms / (seg.max_possible_amplitude or 1))
         times.append((start + end) / 2000.0)
-        rms_db.append(dbfs)
-    return times, rms_db
+        rms_dbfs.append(dbfs)
+    return times, rms_dbfs
 
-def detect_exceedances(rms_db, hop_ms, baseline_db, delta_db, hyst_db, min_event_ms):
+def detect_exceedances(rms_dbfs, hop_ms, baseline_db, delta_db, hyst_db, min_event_ms):
     up_th = baseline_db + delta_db
     down_th = up_th - hyst_db
     events = []
     in_evt = False
     evt_start_idx = None
-    for i, val in enumerate(rms_db):
+    for i, val in enumerate(rms_dbfs):
         if not in_evt and val > up_th:
             in_evt = True
             evt_start_idx = i
@@ -177,7 +177,7 @@ def detect_exceedances(rms_db, hop_ms, baseline_db, delta_db, hyst_db, min_event
             evt_start_idx = None
     if in_evt and evt_start_idx is not None:
         start_ms = evt_start_idx * hop_ms
-        end_ms = len(rms_db) * hop_ms
+        end_ms = len(rms_dbfs) * hop_ms
         if (end_ms - start_ms) >= min_event_ms:
             events.append([start_ms, end_ms])
     return events
@@ -263,7 +263,7 @@ def ffmpeg_cut_h264(input_path: str, output_path: str, start_s: float, end_s: fl
     run_ffmpeg(cmd, "cut_h264")
 
 def ffmpeg_cut_copy(input_path: str, output_path: str, start_s: float, end_s: float):
-    """Нарезка без перекодирования (очень быстро). Выход .avi. Границы — по ключкадрам."""
+    """Нарезка без перекодирования (очень быстро). Выход .avi. Границы — по ключевым кадрам."""
     cmd = [
         "ffmpeg", "-hide_banner", "-y",
         "-ss", f"{start_s}",
@@ -325,17 +325,25 @@ def collect_worklist_from_rar(rar_path, seven_zip_exe):
 
 def extract_one_from_zip(zip_path, arcname):
     tmp_dir = tempfile.mkdtemp(prefix="vid_extract_")
-    out_path = os.path.join(tmp_dir, os.path.basename(arcname))
-    with ZipFile(zip_path, "r") as zf:
-        with zf.open(arcname) as src, open(out_path, "wb") as dst:
-            shutil.copyfileobj(src, dst)
-    return out_path, tmp_dir
+    try:
+        out_path = os.path.join(tmp_dir, os.path.basename(arcname))
+        with ZipFile(zip_path, "r") as zf:
+            with zf.open(arcname) as src, open(out_path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+        return out_path, tmp_dir
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
 def extract_one_from_rar(rar_path, arcname, seven_zip_exe):
     tmp_dir = tempfile.mkdtemp(prefix="vid_extract_")
-    subprocess.run([seven_zip_exe, "e", "-y", rar_path, arcname, f"-o{tmp_dir}"], check=True)
-    out_path = os.path.join(tmp_dir, os.path.basename(arcname))
-    return out_path, tmp_dir
+    try:
+        subprocess.run([seven_zip_exe, "e", "-y", rar_path, arcname, f"-o{tmp_dir}"], check=True)
+        out_path = os.path.join(tmp_dir, os.path.basename(arcname))
+        return out_path, tmp_dir
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
 # ===================== Системные датчики (поток) =====================
 
@@ -490,7 +498,7 @@ def main():
 
             log("[analyze] Считаю кратковременный уровень (RMS)")
             audio = AudioSegment.from_wav(original_wav).set_channels(1)
-            times_sec, rms_db = short_time_rms_dbfs(audio, WIN_MS, HOP_MS)
+            times_sec, rms_dbfs = short_time_rms_dbfs(audio, WIN_MS, HOP_MS)
 
             # Бейзлайн
             if CALIBRATION_SEC > 0:
@@ -500,10 +508,10 @@ def main():
                 baseline_src = f"first {CALIBRATION_SEC}s (median)"
             else:
                 if BASELINE_METHOD.lower() == "median":
-                    baseline_db = median(rms_db) if rms_db else -60.0
+                    baseline_db = median(rms_dbfs) if rms_dbfs else -60.0
                     baseline_src = "global median"
                 else:
-                    baseline_db = percentile(rms_db, 20) if rms_db else -60.0
+                    baseline_db = percentile(rms_dbfs, 20) if rms_dbfs else -60.0
                     baseline_src = "global p20"
 
             up_th = baseline_db + THRESH_DELTA_DB
@@ -512,7 +520,7 @@ def main():
             # Детекция
             log("[detect] Ищу превышения над порогом…")
             events = detect_exceedances(
-                rms_db=rms_db,
+                rms_dbfs=rms_dbfs,
                 hop_ms=HOP_MS,
                 baseline_db=baseline_db,
                 delta_db=THRESH_DELTA_DB,
@@ -525,14 +533,14 @@ def main():
             # Доп. удлинение после склейки
             events = expand_chunks(events, EXTRA_EVENT_EXPAND_MS, total_ms=len(audio))
 
-            if not events and rms_db:
-                max_i = max(range(len(rms_db)), key=lambda i: rms_db[i])
+            if not events and rms_dbfs:
+                max_i = max(range(len(rms_dbfs)), key=lambda i: rms_dbfs[i])
                 center_ms = max_i * HOP_MS
                 half = int(FALLBACK_SEC * 1000 / 2)
                 start_ms = max(0, center_ms - half)
                 end_ms = min(len(audio), center_ms + half)
                 events = [[start_ms, end_ms]]
-                log("[detect] событий не найдено — сохранен самый громкий ~2с сегмент (fallback)")
+                log("[detect] событий не найдено — сохранён самый громкий ~2с сегмент (fallback)")
 
             log(f"[export] Найдено событий: {len(events)} — начинаю экспорт аудио/видео и таймкодов")
             tc_path = os.path.join(out_dir, "timecodes.txt")

--- a/tests/test_expand_chunks.py
+++ b/tests/test_expand_chunks.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal stub for pydub to satisfy analyzer imports during tests
+pydub_stub = types.ModuleType("pydub")
+class AudioSegment:
+    pass
+pydub_stub.AudioSegment = AudioSegment
+sys.modules.setdefault("pydub", pydub_stub)
+
+from analyzer import expand_chunks
+
+
+def test_expand_chunks_basic_and_bounds():
+    chunks = [(100, 200)]
+    result = expand_chunks(chunks, expand_ms=50, total_ms=500)
+    assert result == [[50, 250]]
+
+    # respects boundaries at start and end
+    edge_chunks = [(0, 50), (450, 500)]
+    edge_result = expand_chunks(edge_chunks, expand_ms=100, total_ms=500)
+    assert edge_result == [[0, 150], [350, 500]]

--- a/tests/test_pad_and_merge.py
+++ b/tests/test_pad_and_merge.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal stub for pydub to satisfy analyzer imports during tests
+import types
+pydub_stub = types.ModuleType("pydub")
+
+class AudioSegment:
+    pass
+
+pydub_stub.AudioSegment = AudioSegment
+sys.modules.setdefault("pydub", pydub_stub)
+
+from analyzer import pad_and_merge
+
+def test_pad_and_merge_overlapping_after_padding():
+    # intervals overlap after applying padding
+    chunks = [(100, 200), (250, 300)]
+    result = pad_and_merge(chunks, pad_ms=50)
+    assert result == [[50, 350]]
+
+def test_pad_and_merge_respects_merge_gap():
+    # intervals are merged when gap is within merge_gap_ms
+    chunks = [(0, 100), (150, 200)]
+    result = pad_and_merge(chunks, pad_ms=0, merge_gap_ms=50)
+    assert result == [[0, 200]]
+
+    # intervals remain separate when gap exceeds merge_gap_ms
+    chunks_far = [(0, 100), (250, 300)]
+    result_far = pad_and_merge(chunks_far, pad_ms=0, merge_gap_ms=50)
+    assert result_far == [[0, 100], [250, 300]]


### PR DESCRIPTION
## Summary
- rename RMS variables and arguments to reflect dBFS
- clean up temp directory when RAR extraction fails
- fix Russian typo in fallback log message
- add tests for `expand_chunks` covering boundaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0fe9453bc83298506a7d3894e13f2