### PR TITLE
Merge overlapping chunks after expansion

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -196,8 +196,8 @@ def pad_and_merge(chunks, pad_ms, merge_gap_ms=0):
             merged.append([s, e])
     return merged
 
-def expand_chunks(chunks, expand_ms, total_ms):
-    """Добавляет по expand_ms с каждой стороны (после склейки)."""
+def expand_chunks(chunks, expand_ms, total_ms, merge_gap_ms=0):
+    """Добавляет по expand_ms с каждой стороны (после склейки) и объединяет перекрытия."""
     if not chunks or expand_ms <= 0:
         return chunks
     out = []
@@ -205,7 +205,7 @@ def expand_chunks(chunks, expand_ms, total_ms):
         s2 = max(0, s - expand_ms)
         e2 = min(total_ms, e + expand_ms)
         out.append([s2, e2])
-    return out
+    return pad_and_merge(out, pad_ms=0, merge_gap_ms=merge_gap_ms)
 
 # ===================== FFmpeg =====================
 
@@ -531,7 +531,7 @@ def main():
             # Поля и склейка
             events = pad_and_merge(events, KEEP_SILENCE_MS, MERGE_GAP_MS)
             # Доп. удлинение после склейки
-            events = expand_chunks(events, EXTRA_EVENT_EXPAND_MS, total_ms=len(audio))
+            events = expand_chunks(events, EXTRA_EVENT_EXPAND_MS, total_ms=len(audio), merge_gap_ms=MERGE_GAP_MS)
 
             if not events and rms_dbfs:
                 max_i = max(range(len(rms_dbfs)), key=lambda i: rms_dbfs[i])

--- a/tests/test_expand_chunks.py
+++ b/tests/test_expand_chunks.py
@@ -23,3 +23,10 @@ def test_expand_chunks_basic_and_bounds():
     edge_chunks = [(0, 50), (450, 500)]
     edge_result = expand_chunks(edge_chunks, expand_ms=100, total_ms=500)
     assert edge_result == [[0, 150], [350, 500]]
+
+
+def test_expand_chunks_merges_overlaps():
+    chunks = [(100, 150), (160, 210)]
+    # expanding by 30ms causes the ranges to overlap
+    result = expand_chunks(chunks, expand_ms=30, total_ms=500)
+    assert result == [[70, 240]]


### PR DESCRIPTION
## Summary
- merge expanded audio chunks using `pad_and_merge`
- adjust analyzer to pass merge gap into expansion
- test merging behavior when expanded chunks overlap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10b08b7d08329901167f18098a554