### PR TITLE
Clarify short_time_rms_dbfs docstring

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -148,11 +148,10 @@ def short_time_rms_dbfs(audio: AudioSegment, win_ms=50, hop_ms=50):
     """Возвращает ``(times_sec, rms_dbfs)``.
 
     * ``times_sec`` — центр окна в секундах;
-    * ``rms_dbfs`` — уровень сигнала, выраженный в dBFS.
+    * ``rms_dbfs`` — уровень сигнала в dBFS.
 
-    Параметры ``win_ms`` и ``hop_ms`` задаются в миллисекундах и по умолчанию
-    равны ``50`` ms. Значения по умолчанию отличаются от глобальных
-    констант ``WIN_MS`` и ``HOP_MS`` (``25`` ms).
+    ``win_ms`` и ``hop_ms`` задаются в миллисекундах,
+    по умолчанию равны ``50`` ms.
     """
     n = max(1, math.ceil((len(audio) - win_ms) / hop_ms) + 1)
     times, rms_dbfs = [], []


### PR DESCRIPTION
## Summary
- Clarify that short_time_rms_dbfs returns RMS levels in dBFS
- Note that win_ms and hop_ms are specified in milliseconds with 50 ms defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b10eab40bc83298b53476cf976c1f4