### PR TITLE
Ensure expanded chunks are merged

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -205,15 +205,18 @@ def pad_and_merge(chunks, pad_ms, merge_gap_ms=0):
     return merged
 
 def expand_chunks(chunks, expand_ms, total_ms, merge_gap_ms=0):
-    """Добавляет по expand_ms с каждой стороны (после склейки) и объединяет перекрытия."""
-    if not chunks or expand_ms <= 0:
-        return chunks
-    out = []
+    """Добавляет по ``expand_ms`` с каждой стороны и объединяет перекрытия."""
+    if not chunks:
+        return []
+
+    expanded = []
     for s, e in chunks:
-        s2 = max(0, s - expand_ms)
-        e2 = min(total_ms, e + expand_ms)
-        out.append([s2, e2])
-    return pad_and_merge(out, pad_ms=0, merge_gap_ms=merge_gap_ms)
+        if expand_ms > 0:
+            s = max(0, s - expand_ms)
+            e = min(total_ms, e + expand_ms)
+        expanded.append([s, e])
+
+    return pad_and_merge(expanded, pad_ms=0, merge_gap_ms=merge_gap_ms)
 
 # ===================== FFmpeg =====================
 

--- a/tests/test_expand_chunks.py
+++ b/tests/test_expand_chunks.py
@@ -30,3 +30,13 @@ def test_expand_chunks_merges_overlaps():
     # expanding by 30ms causes the ranges to overlap
     result = expand_chunks(chunks, expand_ms=30, total_ms=500)
     assert result == [[70, 240]]
+
+
+def test_expand_chunks_no_overlaps_in_result():
+    chunks = [(10, 20), (40, 50), (90, 100)]
+    result = expand_chunks(chunks, expand_ms=10, total_ms=150, merge_gap_ms=5)
+
+    # first two chunks merge, but final intervals should be non-overlapping
+    assert result == [[0, 60], [80, 110]]
+    for (s1, e1), (s2, e2) in zip(result, result[1:]):
+        assert e1 < s2


### PR DESCRIPTION
## Summary
- Refactor expand_chunks to always merge overlapping intervals after optional expansion via pad_and_merge
- Add test verifying expanded intervals remain non-overlapping

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10e9d7c6483299ed4e31deaba195f