### PR TITLE
Clarify units in short_time_rms_dbfs docstring

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -148,10 +148,9 @@ def short_time_rms_dbfs(audio: AudioSegment, win_ms=50, hop_ms=50):
     """Возвращает ``(times_sec, rms_dbfs)``.
 
     * ``times_sec`` — центр окна в секундах;
-    * ``rms_dbfs`` — уровень сигнала в dBFS.
+    * ``rms_dbfs`` — уровень сигнала в децибелах относительно полного масштаба (dBFS).
 
-    ``win_ms`` и ``hop_ms`` задаются в миллисекундах,
-    по умолчанию равны ``50`` ms.
+    Параметры ``win_ms`` и ``hop_ms`` измеряются в миллисекундах (по умолчанию по ``50`` ms).
     """
     n = max(1, math.ceil((len(audio) - win_ms) / hop_ms) + 1)
     times, rms_dbfs = [], []


### PR DESCRIPTION
## Summary
- note that `win_ms` and `hop_ms` parameters are in milliseconds with 50 ms defaults
- clarify that `rms_dbfs` is returned in dBFS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b113617b3c8329b855d95178582493