### PR TITLE
Use MERGE_GAP_MS when expanding chunks

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -202,7 +202,7 @@ def pad_and_merge(chunks, pad_ms, merge_gap_ms=0):
             merged.append([s, e])
     return merged
 
-def expand_chunks(chunks, expand_ms, total_ms, merge_gap_ms=0):
+def expand_chunks(chunks, expand_ms, total_ms):
     """Добавляет по ``expand_ms`` с каждой стороны и объединяет перекрытия."""
     if not chunks:
         return []
@@ -214,7 +214,7 @@ def expand_chunks(chunks, expand_ms, total_ms, merge_gap_ms=0):
             e = min(total_ms, e + expand_ms)
         out.append([s, e])
 
-    return pad_and_merge(out, 0, merge_gap_ms)
+    return pad_and_merge(out, 0, MERGE_GAP_MS)
 
 # ===================== FFmpeg =====================
 
@@ -540,7 +540,7 @@ def main():
             # Поля и склейка
             events = pad_and_merge(events, KEEP_SILENCE_MS, MERGE_GAP_MS)
             # Доп. удлинение после склейки
-            events = expand_chunks(events, EXTRA_EVENT_EXPAND_MS, total_ms=len(audio), merge_gap_ms=MERGE_GAP_MS)
+            events = expand_chunks(events, EXTRA_EVENT_EXPAND_MS, total_ms=len(audio))
 
             if not events and rms_dbfs:
                 max_i = max(range(len(rms_dbfs)), key=lambda i: rms_dbfs[i])

--- a/tests/test_expand_chunks.py
+++ b/tests/test_expand_chunks.py
@@ -19,10 +19,10 @@ def test_expand_chunks_basic_and_bounds():
     result = expand_chunks(chunks, expand_ms=50, total_ms=500)
     assert result == [[50, 250]]
 
-    # respects boundaries at start and end
-    edge_chunks = [(0, 50), (450, 500)]
-    edge_result = expand_chunks(edge_chunks, expand_ms=100, total_ms=500)
-    assert edge_result == [[0, 150], [350, 500]]
+    # respects boundaries at start and end without merging distant chunks
+    edge_chunks = [(0, 50), (480, 500)]
+    edge_result = expand_chunks(edge_chunks, expand_ms=50, total_ms=500)
+    assert edge_result == [[0, 100], [430, 500]]
 
 
 def test_expand_chunks_merges_overlaps():
@@ -35,10 +35,10 @@ def test_expand_chunks_merges_overlaps():
 
 
 def test_expand_chunks_no_overlaps_in_result():
-    chunks = [(10, 20), (40, 50), (90, 100)]
-    result = expand_chunks(chunks, expand_ms=10, total_ms=150, merge_gap_ms=5)
+    chunks = [(10, 20), (40, 50), (400, 410)]
+    result = expand_chunks(chunks, expand_ms=10, total_ms=500)
 
     # first two chunks merge, but final intervals should be non-overlapping
-    assert result == [[0, 60], [80, 110]]
+    assert result == [[0, 60], [390, 420]]
     for (s1, e1), (s2, e2) in zip(result, result[1:]):
         assert e1 < s2


### PR DESCRIPTION
## Summary
- Merge expanded chunks using global MERGE_GAP_MS
- Adjust tests to reflect automatic merging behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1140491e083299d240dcdc93411f9